### PR TITLE
build: aarch64: CMakeLists.txt for JIT code generation for AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,13 +89,13 @@ endif()
 
 # Set the target architecture.
 if(NOT DNNL_TARGET_ARCH)
-#    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
         set(DNNL_TARGET_ARCH "AARCH64")
-#    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64.*|PPC64.*)")
-#        set(DNNL_TARGET_ARCH "PPC64")
-#    else()
-#        set(DNNL_TARGET_ARCH "X64")
-#    endif()
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ppc64.*|PPC64.*)")
+        set(DNNL_TARGET_ARCH "PPC64")
+    else()
+        set(DNNL_TARGET_ARCH "X64")
+    endif()
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
@@ -119,6 +119,7 @@ include("cmake/Threadpool.cmake")
 include("cmake/OpenCL.cmake")
 include("cmake/platform.cmake")
 include("cmake/SDL.cmake")
+include("cmake/xed.cmake")
 include("cmake/blas.cmake")
 include("cmake/Doxygen.cmake")
 include("cmake/version.cmake")
@@ -155,26 +156,6 @@ endif()
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
-
-# TODO: aarch64 only
-if(DNNL_INDIRECT_JIT_AARCH64)
-    append(CMAKE_C_FLAGS "-DDNNL_INDIRECT_JIT_AARCH64")
-    append(CMAKE_CXX_FLAGS "-DDNNL_INDIRECT_JIT_AARCH64")
-
-    append(CMAKE_C_FLAGS "-DXBYAK_TRANSLATE_AARCH64")
-    append(CMAKE_CXX_FLAGS "-DXBYAK_TRANSLATE_AARCH64")
-endif()
-
-if(DNNL_INDIRECT_JIT_AARCH64 OR DNNL_NATIVE_JIT_AARCH64)
-    append(CMAKE_C_FLAGS "-DXBYAK_AARCH64_FOR_DNNL")
-    append(CMAKE_CXX_FLAGS "-DXBYAK_AARCH64_FOR_DNNL")
-endif()
-
-if(DNNL_NATIVE_JIT_AARCH64)
-    append(CMAKE_C_FLAGS "-DDNNL_NATIVE_JIT_AARCH64")
-    append(CMAKE_CXX_FLAGS "-DDNNL_NATIVE_JIT_AARCH64")
-endif()
-
 
 add_subdirectory(src)
 add_subdirectory(examples)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,21 +100,6 @@ target_include_directories(${LIB_NAME} PUBLIC
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>
     )
 
-if(DNNL_INDIRECT_JIT_AARCH64)
-    find_library(XED
-        NAMES "xed"
-        PATHS cpu/aarch64/build_xed_aarch64/kits/xed/lib /usr/local/lib /usr/lib /usr/local/lib64 /usr/lib64 /usr/lib/aarch64-linux-gnu
-        ENV LD_LIBRARY_PATH
-    )
-
-    if(NOT XED)
-        message(FATAL_ERROR, "libxed not found!")
-    endif()
-
-    list(APPEND EXTRA_STATIC_LIBS ${XED})
-    list(APPEND EXTRA_SHARED_LIBS ${XED})
-endif()
-
 target_link_libraries_build(${LIB_NAME}
     "${EXTRA_SHARED_LIBS};${EXTRA_STATIC_LIBS}")
 target_link_libraries_install(${LIB_NAME} "${EXTRA_SHARED_LIBS}")

--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -65,25 +65,28 @@ add_library(${OBJ_LIB} OBJECT ${SOURCES})
 set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
     $<TARGET_OBJECTS:${OBJ_LIB}>)
 
-# TODO: aarch64 only 
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64
-    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64/xbyak
-    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64/translator/include/xbyak_translator_for_aarch64
-    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64/translator/third_party/xbyak_aarch64/xbyak_aarch64
-    )
-
-if(DNNL_INDIRECT_JIT_AARCH64)
-    include_directories(
-        ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/build_xed_aarch64/kits/xed/include
-    )
-endif()
-
-
 if (DNNL_TARGET_ARCH STREQUAL "X64")
     add_subdirectory(x64)
 endif()
 
 if (DNNL_TARGET_ARCH STREQUAL "AARCH64")
-    add_subdirectory(aarch64)
+
+  if(DNNL_INDIRECT_JIT_AARCH64)
+    append(CMAKE_C_FLAGS "-DDNNL_INDIRECT_JIT_AARCH64")
+    append(CMAKE_CXX_FLAGS "-DDNNL_INDIRECT_JIT_AARCH64")
+
+    append(CMAKE_C_FLAGS "-DXBYAK_TRANSLATE_AARCH64")
+    append(CMAKE_CXX_FLAGS "-DXBYAK_TRANSLATE_AARCH64")
+
+    append(CMAKE_C_FLAGS "-DXBYAK_AARCH64_FOR_DNNL")
+    append(CMAKE_CXX_FLAGS "-DXBYAK_AARCH64_FOR_DNNL")
+  endif()
+
+  include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64/xbyak
+    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64/translator/include/xbyak_translator_for_aarch64
+    ${CMAKE_CURRENT_SOURCE_DIR}/aarch64/xbyak_translator_aarch64/translator/third_party/xbyak_aarch64/xbyak_aarch64
+    )
+
+  add_subdirectory(aarch64)
 endif()

--- a/src/cpu/aarch64/CMakeLists.txt
+++ b/src/cpu/aarch64/CMakeLists.txt
@@ -1,5 +1,6 @@
 #===============================================================================
 # Copyright 2020 Intel Corporation
+# Copyright 2020 FUJITSU LIMITED
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,18 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #===============================================================================
+option(DNNL_INDIRECT_JIT_AARCH64 "enables indirect JIT for AArch64." ON)
+    # enabled by default
+option(DNNL_NATIVE_JIT_AARCH64 "enables native JIT for AArch64." ON)
+    # enabled by default
 
 
 file(GLOB SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch]
     ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch]pp
-    )
-
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/xbyak_translator_aarch64
-    ${CMAKE_CURRENT_SOURCE_DIR}/xbyak_translator_aarch64/xbyak
-    ${CMAKE_CURRENT_SOURCE_DIR}/xbyak_translator_aarch64/translator/include/xbyak_translator_for_aarch64
-    ${CMAKE_CURRENT_SOURCE_DIR}/xbyak_translator_aarch64/translator/third_party/xbyak_aarch64/xbyak_aarch64
     )
 
 if(NOT DNNL_ENABLE_JIT_PROFILING)
@@ -37,10 +35,18 @@ if(NOT DNNL_ENABLE_JIT_PROFILING)
         )
 endif()
 
+if(DNNL_INDIRECT_JIT_AARCH64)
+    append(CMAKE_C_FLAGS "-DDNNL_INDIRECT_JIT_AARCH64")
+    append(CMAKE_CXX_FLAGS "-DDNNL_INDIRECT_JIT_AARCH64")
+
+    append(CMAKE_C_FLAGS "-DXBYAK_TRANSLATE_AARCH64")
+    append(CMAKE_CXX_FLAGS "-DXBYAK_TRANSLATE_AARCH64")
+
+    append(CMAKE_C_FLAGS "-DXBYAK_AARCH64_FOR_DNNL")
+    append(CMAKE_CXX_FLAGS "-DXBYAK_AARCH64_FOR_DNNL")
+endif()
 
 set(OBJ_LIB ${LIB_NAME}_cpu_aarch64)
 add_library(${OBJ_LIB} OBJECT ${SOURCES})
 set_property(GLOBAL APPEND PROPERTY DNNL_LIB_DEPS
     $<TARGET_OBJECTS:${OBJ_LIB}>)
-
-


### PR DESCRIPTION
CMakeLists.txt files are modified to support JIT code generation for AArch64.
Environment variable XED_ROOT_DIR is required for pointing the XED directory.  