### PR TITLE
ci: add fcc, OpenBLAS, SSL2 to gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,8 +115,8 @@ fcc_w/_SSL2:
   - git submodule update --init --recursive
   - PATH=${PATH}:/opt/FJSVstclanga/v1.0.0/bin
   - export LD_LIBRARY_PATH=/opt/FJSVstclanga/v1.0.0/lib64:/usr/lib64/libcblas.so.3
-  - export CC="fcc -Nclang -Knolargepage -Kopenmp,SVE"
-  - export CXX="FCC -Nclang -Knolargepage -Kopenmp,SVE"
+  - export CC="fcc -Nclang -Knolargepage -Kopenmp"
+  - export CXX="FCC -Nclang -Knolargepage -Kopenmp"
   - export ONEDNN_ROOT_DIR=`pwd`
   - cd src/cpu/aarch64/xbyak_translator_aarch64/translator/third_party/
   - mkdir build_xed_aarch64


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## Code-change submissions

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [ ] Have you formatted the code using clang-format?

### New features

- [ ] Have you added relevant tests?
- [ ] Have you provided motivation for adding a new feature?

### Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
